### PR TITLE
update repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:opensumi/Default-Themes.git"
+    "url": "https://github.com/opensumi/Default-Themes"
   },
   "publishConfig": {
     "registry": "http://registry.npm.alibaba-inc.com"


### PR DESCRIPTION
Using `https` link address so that the Extension Market could recognize.

---

The old link shows like this, which is a wrong link. 

<img width="1420" alt="Screen Shot 2021-12-28 at 10 31 48" src="https://user-images.githubusercontent.com/24731539/147521492-dd02da98-2af7-4f23-8a8d-3cb4eae70ca4.png">

